### PR TITLE
Change to use offset-based coordinates

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,15 +1,16 @@
 {
   "name": "jquery.ui.resizable.snap.ext",
   "description": "Enhance the jQuery UI Resizable plugin with the same snap functionality that is offered by the jQuery UI Draggable plugin.",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "keywords": [
     "jquery",
     "snap",
     "js"
   ],
-  "homepage": "https://github.com/polomoshnov/jQuery-UI-Resizable-Snap-extension",
+  "homepage": "https://github.com/cudasteve/jQuery-UI-Resizable-Snap-extension",
   "authors": [
-    "Alexander Polomoshnov"
+    "Alexander Polomoshnov",
+    "Steve Shaffer"
   ],
   "main": [
     "jquery.ui.resizable.snap.ext.js"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "jquery.ui.resizable.snap.ext",
   "description": "Enhance the jQuery UI Resizable plugin with the same snap functionality that is offered by the jQuery UI Draggable plugin.",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "keywords": [
     "jquery",
     "snap",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "jquery.ui.resizable.snap.ext",
   "description": "Enhance the jQuery UI Resizable plugin with the same snap functionality that is offered by the jQuery UI Draggable plugin.",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "keywords": [
     "jquery",
     "snap",

--- a/jquery.ui.resizable.snap.ext.js
+++ b/jquery.ui.resizable.snap.ext.js
@@ -148,6 +148,14 @@
 		}
 	});
 	
+	var gridIndex = -1;
+	$.each(p, function (k, v) {
+		if (v[0] == 'grid') gridIndex = k;
+		if (gridIndex > 0 && v[0] == 'snap') {
+			p.splice(gridIndex, 0, p.splice(k, 1)[0]);
+		}
+	});
+
 	$.each($.ui.resizable.prototype.plugins.start, function (k, v) {
 		if (v[0] == 'ghost') {
 			var fn = v[1];

--- a/jquery.ui.resizable.snap.ext.js
+++ b/jquery.ui.resizable.snap.ext.js
@@ -21,7 +21,7 @@
 			$(typeof snap == 'string' ? snap : ':data(ui-resizable)').each(function () {
 				if (this == inst.element[0] || this == inst.helper[0]) return;
 			
-				var $el = $(this), p = $el.position(), 
+				var $el = $(this), p = $el.offset(),  // TODO: o
 					l = p.left + getLm($el), t = p.top + getTm($el);
 					
 				inst.coords.push({ 
@@ -35,8 +35,8 @@
 				axes = inst.axis.split(''),
 				st = inst.options.snapTolerance,
 				md = inst.options.snapMode,
-				l = inst.position.left + inst.lm, _l = l - st,
-				t = inst.position.top + inst.tm, _t = t - st,
+				l = inst.offset.left + inst.lm, _l = l - st,
+				t = inst.offset.top + inst.tm, _t = t - st,
 				r = l + inst.size.width + inst.ow, _r = r + st,
 				b = t + inst.size.height + inst.oh, _b = b + st;
 				

--- a/jquery.ui.resizable.snap.ext.js
+++ b/jquery.ui.resizable.snap.ext.js
@@ -17,6 +17,8 @@
 			inst.lm = getLm($this);
 			inst.tm = getTm($this);
 			inst.coords = [];
+			inst.hasGridX = inst.options.grid && inst.options.grid[0] > 1;
+			inst.hasGridY = inst.options.grid && inst.options.grid[1] > 1;
 			
 			$(typeof snap == 'string' ? snap : ':data(ui-resizable)').each(function () {
 				if (this == inst.element[0] || this == inst.helper[0]) return;
@@ -61,10 +63,10 @@
 					}
 					
 					switch (axis) {
-						case 'w': ls.push(getC(l - coords.l, l - coords.r, st)); break;
-						case 'n': ts.push(getC(t - coords.t, t - coords.b, st)); break;
-						case 'e': ws.push(getC(r - coords.l, r - coords.r, st)); break;
-						case 's': hs.push(getC(b - coords.t, b - coords.b, st));
+						case 'w': inst.hasGridX || ls.push(getC(l - coords.l, l - coords.r, st)); break;
+						case 'n': inst.hasGridY || ts.push(getC(t - coords.t, t - coords.b, st)); break;
+						case 'e': inst.hasGridX || ws.push(getC(r - coords.l, r - coords.r, st)); break;
+						case 's': inst.hasGridY || hs.push(getC(b - coords.t, b - coords.b, st));
 					}
 				});
 			});
@@ -145,14 +147,6 @@
 		if (v[0] == 'ghost') {
 			p.splice(k, 1);
 			return false;
-		}
-	});
-	
-	var gridIndex = -1;
-	$.each(p, function (k, v) {
-		if (v[0] == 'grid') gridIndex = k;
-		if (gridIndex > 0 && v[0] == 'snap') {
-			p.splice(gridIndex, 0, p.splice(k, 1)[0]);
 		}
 	});
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "jquery.ui.resizable.snap.ext",
+  "version": "1.9.4",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cudasteve/jQuery-UI-Resizable-Snap-extension"
+  }
+}


### PR DESCRIPTION
This allows us to support snapping to items that are under different offset parents and uses similar logic to jQueryUI draggable snap.  This should close #8.

If I get a little time, I'll try to put together a demo of before/after the fix, but I likely won't have time until after the new year.

DISCLAIMER: I have not tested this with ghosts or other options besides the options that this plugin adds.  I'm not really sure how to thoroughly test this, so verify all the previous use cases still work before merging.
